### PR TITLE
Add roadmaps directory for saved files

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from rich.markdown import Markdown
 from config import APP_NAME, APP_VERSION
 from loading_animation import LoadingAnimation, AnimationType
 import threading
+import os
 
 app = typer.Typer()
 console = Console()
@@ -135,11 +136,13 @@ def save(
             # Stop the animation
             roadmap_animation.stop()
         
-        # Save to file
-        with open(output_file, "w") as f:
+        # Save to file in the roadmaps directory
+        os.makedirs('roadmaps', exist_ok=True)  # Ensure the directory exists
+        file_path = os.path.join('roadmaps', output_file)
+        with open(file_path, "w") as f:
             f.write(roadmap)
         
-        console.print(f"\n[bold green]Roadmap saved to {output_file}[/bold green]")
+        console.print(f"\n[bold green]Roadmap saved to {file_path}[/bold green]")
     except Exception as e:
         # Ensure animation is stopped in case of error
         if 'roadmap_animation' in locals():

--- a/roadmap_generator.py
+++ b/roadmap_generator.py
@@ -57,8 +57,6 @@ async def generate_roadmap_with_questions(idea_description, animation_type=Anima
     if status_callback:
         status_callback("✅ Initial roadmap generation complete!")
     
-    print("\nInitial roadmap complete!")
-    
     # Generate questions animation
     questions_animation = LoadingAnimation("Analyzing roadmap and generating customized questions", animation_type)
     questions_animation.start()
@@ -137,9 +135,14 @@ def main():
     print("\nRoadmap generation complete!")
     
     if args.output:
-        with open(args.output, 'w') as f:
+        import os
+        # Ensure roadmaps directory exists
+        os.makedirs('roadmaps', exist_ok=True)
+        # Save to roadmaps directory
+        file_path = os.path.join('roadmaps', args.output)
+        with open(file_path, 'w') as f:
             f.write(roadmap)
-        print(f"Roadmap saved to {args.output}")
+        print(f"Roadmap saved to {file_path}")
     else:
         print("\n" + roadmap)
 


### PR DESCRIPTION
This PR adds a 'roadmaps' directory to store generated roadmap files. It updates both the CLI interface in main.py and the roadmap_generator.py script to save files to this directory.

Changes:
- Created an empty 'roadmaps' directory with .gitkeep
- Updated main.py to save roadmaps to the roadmaps directory
- Updated roadmap_generator.py to save roadmaps to the roadmaps directory